### PR TITLE
Korrigert informasjon om serverfeil og tidsavbrudd

### DIFF
--- a/content/fiks-plattform/tjenester/fiksprotokoll/arkiv.md
+++ b/content/fiks-plattform/tjenester/fiksprotokoll/arkiv.md
@@ -97,7 +97,7 @@ Når en melding er mottatt skal mottaker persistere meldingen og sende `ack` til
 
 En `ack` melding må ikke forveksles med `mottatt`meldingene som sendes tilbake i noen tilfeller. En `mottatt`melding er en melding tilbake til avsender, en `ack`melding er **kun** en beskjed tilbake til køen om å fjerne meldingen.
 
-Hvis `ack` for en melding uteblir vil meldingen bli værende på køen inntil den er blitt hentet 3 ganger uten å få en `ack` tilbake. Da vil Fiks-IO sende en `no.ks.fiks.io.feilmelding.serverfeil` melding tilbake til avsender. Med andre ord er det viktig at man sender `ack` når man vellykket har hentet en melding. 
+Hvis `ack` for en melding uteblir vil meldingen bli værende på køen inntil den er blitt hentet 3 ganger uten å få en `ack` tilbake. Da vil Fiks-IO sende en `no.ks.fiks.io.feilmelding.serverfeil.v1` melding tilbake til avsender. Med andre ord er det viktig at man sender `ack` når man vellykket har hentet en melding. 
 
 OBS: Dette erstatter tidligere TTL-håndtering på Fiks-IO køene. Det vil ikke lenger sendes noen `tidsavbrudd` meldinger basert på TTL. 
 

--- a/content/fiks-plattform/tjenester/fiksprotokoll/fiksio/_index.md
+++ b/content/fiks-plattform/tjenester/fiksprotokoll/fiksio/_index.md
@@ -98,8 +98,7 @@ Disse meldingene inneholder ingen body, men kun headere deriblant `svar-til` som
 __NB! Siden utløp av meldinger ikke vil fungere godt om det ligger flere meldinger på kø vil denne funksjonaliteten fases ut snart. I stedet vil man få en [serverfeil](#serverfeil) når en melding er avvist tre ganger__
 
 #### Serverfeil
-Ved serverfeil hos mottaker skal det sendes en `no.ks.fiks.io.feilmelding.serverfeil` tilbake til sender. Json [schema](https://github.com/ks-no/fiks-io-client-dotnet/blob/master/KS.Fiks.IO.Client/Schema/no.ks.fiks.kvittering.serverfeil.v1.schema.json) følger med i .net pakken for Fiks-IO-client.
-
+I noen tilfeller vil Fiks-IO sende en `no.ks.fiks.io.feilmelding.serverfeil.v1` feilmelding tilbake, som f.eks. når en melding har blitt forsøkt hentet 3 ganger uten å sende ack tilbake til Fiks-IO.  
 
 ### Håndtering av store filer
 Fiks IO støtter sending av store filer ved at alle meldinger større enn 5 megabyte mellomlagres i Fiks Dokumentlager, i en dedikert konto som opprettes sammen med Fiks IO kontoen. En referanse til denne lagrede filen blir så sendt over AMQP. Filer sendt på slik måte får en time-to-live i dokumentlager lik time-to-live for meldingen + 24 timer. Etter dette vil de automatisk slettes.

--- a/content/fiks-plattform/tjenester/fiksprotokoll/fiksio/_index.md
+++ b/content/fiks-plattform/tjenester/fiksprotokoll/fiksio/_index.md
@@ -95,10 +95,7 @@ Hvis mottaker er nede og ikke leser meldinger og første melding har ttl på 2 t
 
 Disse meldingene inneholder ingen body, men kun headere deriblant `svar-til` som vil være en referanse til den opprinnelige meldingen (melding-id), `svar-til-type` som inneholder den originale typen på meldingen som har utløpt.
 
-__NB! Siden utløp av meldinger ikke vil fungere godt om det ligger flere meldinger på kø vil denne funksjonaliteten fases ut snart. I stedet vil man få en [serverfeil](#serverfeil) når en melding er avvist tre ganger__
-
-#### Serverfeil
-I noen tilfeller vil Fiks-IO sende en `no.ks.fiks.io.feilmelding.serverfeil.v1` feilmelding tilbake, som f.eks. når en melding har blitt forsøkt hentet 3 ganger uten å sende ack tilbake til Fiks-IO.  
+__NB! Siden utløp av meldinger ikke vil fungere godt om det ligger flere meldinger på kø vil denne funksjonaliteten fases ut snart. I stedet vil man få en `no.ks.fiks.io.feilmelding.serverfeil.v1` når en melding er avvist tre ganger__
 
 ### Håndtering av store filer
 Fiks IO støtter sending av store filer ved at alle meldinger større enn 5 megabyte mellomlagres i Fiks Dokumentlager, i en dedikert konto som opprettes sammen med Fiks IO kontoen. En referanse til denne lagrede filen blir så sendt over AMQP. Filer sendt på slik måte får en time-to-live i dokumentlager lik time-to-live for meldingen + 24 timer. Etter dette vil de automatisk slettes.


### PR DESCRIPTION
Det var ikke helt riktig navn på feilmelding og ikke korrekt at det vil sendes fra klienten.

Jeg er også usikker på om det burde være en mer selvforklarende feilmelding når en mottaker ikke har ack'et meldingene. Etter at jeg måtte hjelpe noen med problemer med Fiks-IO og Fiks-Protokoller som støtte på denne meldingen ser jeg at det var ikke selvforklarende. Vi må enten sørge for at forklaringen på hva som er årsaken til serverfeil kommer med i feilmeldingen eller gi den et annet navn som er mer selvforklarende.
